### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,4 +1,3 @@
 # These are supported funding model platforms
 
 github: Benjie
-patreon: Benjie


### PR DESCRIPTION
Remove Patreon from funding sources

_we are having issues with the Pateon payment provider, it's time to remove Patreon as a signposted way of sponsoring us_
